### PR TITLE
fix icon applying after 4th loadout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 nbactions.xml
 nb-configuration.xml
 nbproject/
+bin/

--- a/src/main/java/com/github/dappermickie/runepouch/loadout/names/RunepouchLoadoutNamesPlugin.java
+++ b/src/main/java/com/github/dappermickie/runepouch/loadout/names/RunepouchLoadoutNamesPlugin.java
@@ -4,6 +4,8 @@ import com.google.common.base.Strings;
 import com.google.inject.Provides;
 import java.awt.Color;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import javax.inject.Inject;
 
 import lombok.extern.slf4j.Slf4j;
@@ -53,6 +55,33 @@ public class RunepouchLoadoutNamesPlugin extends Plugin
 	private static final int RUNEPOUCH_LOADOUT_ICON_BG_SPRITE_ID_START = 912;
 	private static final int RUNEPOUCH_LOADOUT_ICON_BG_SPRITE_ID_END = 920;
 
+	private static final int[] LOADOUT_INTERFACE_IDS = {
+		InterfaceID.Bankside.RUNEPOUCH_LOADOUT_A,
+		InterfaceID.Bankside.RUNEPOUCH_LOADOUT_B,
+		InterfaceID.Bankside.RUNEPOUCH_LOADOUT_C,
+		InterfaceID.Bankside.RUNEPOUCH_LOADOUT_D,
+		InterfaceID.Bankside.RUNEPOUCH_LOADOUT_E,
+		InterfaceID.Bankside.RUNEPOUCH_LOADOUT_F,
+		InterfaceID.Bankside.RUNEPOUCH_LOADOUT_G,
+		InterfaceID.Bankside.RUNEPOUCH_LOADOUT_H,
+		InterfaceID.Bankside.RUNEPOUCH_LOADOUT_I,
+		InterfaceID.Bankside.RUNEPOUCH_LOADOUT_J,
+	};
+
+	private static final Map<Integer, Integer> LOAD_INTERFACE_IDS = new HashMap<Integer, Integer>() {{
+		put(InterfaceID.Bankside.RUNEPOUCH_LOAD_A, 1);
+		put(InterfaceID.Bankside.RUNEPOUCH_LOAD_B, 2);
+		put(InterfaceID.Bankside.RUNEPOUCH_LOAD_C, 3);
+		put(InterfaceID.Bankside.RUNEPOUCH_LOAD_D, 4);
+		put(InterfaceID.Bankside.RUNEPOUCH_LOAD_E, 5);
+		put(InterfaceID.Bankside.RUNEPOUCH_LOAD_F, 6);
+		put(InterfaceID.Bankside.RUNEPOUCH_LOAD_G, 7);
+		put(InterfaceID.Bankside.RUNEPOUCH_LOAD_H, 8);
+		put(InterfaceID.Bankside.RUNEPOUCH_LOAD_I, 9);
+		put(InterfaceID.Bankside.RUNEPOUCH_LOAD_J, 10);
+	}};
+
+
 	private int lastRunepouchVarbitValue = 0;
 
 	@Override
@@ -92,39 +121,10 @@ public class RunepouchLoadoutNamesPlugin extends Plugin
 
 		var widgetId = widget.getId();
 
-		switch (widgetId)
-		{
-			case InterfaceID.Bankside.RUNEPOUCH_LOAD_A:
-				setLeftClickMenu(1, actions, firstEntry);
-				break;
-			case InterfaceID.Bankside.RUNEPOUCH_LOAD_B:
-				setLeftClickMenu(2, actions, firstEntry);
-				break;
-			case InterfaceID.Bankside.RUNEPOUCH_LOAD_C:
-				setLeftClickMenu(3, actions, firstEntry);
-				break;
-			case InterfaceID.Bankside.RUNEPOUCH_LOAD_D:
-				setLeftClickMenu(4, actions, firstEntry);
-				break;
-			case InterfaceID.Bankside.RUNEPOUCH_LOAD_E:
-				setLeftClickMenu(5, actions, firstEntry);
-				break;
-			case InterfaceID.Bankside.RUNEPOUCH_LOAD_F:
-				setLeftClickMenu(6, actions, firstEntry);
-				break;
-			case InterfaceID.Bankside.RUNEPOUCH_LOAD_G:
-				setLeftClickMenu(7, actions, firstEntry);
-				break;
-			case InterfaceID.Bankside.RUNEPOUCH_LOAD_H:
-				setLeftClickMenu(8, actions, firstEntry);
-				break;
-			case InterfaceID.Bankside.RUNEPOUCH_LOAD_I:
-				setLeftClickMenu(9, actions, firstEntry);
-				break;
-			case InterfaceID.Bankside.RUNEPOUCH_LOAD_J:
-				setLeftClickMenu(10, actions, firstEntry);
-				break;
-		}
+		var loadoutId = LOAD_INTERFACE_IDS.get(widgetId);
+		if (loadoutId == null) return;
+
+		setLeftClickMenu(loadoutId, actions, firstEntry);
 	}
 
 	private void setLeftClickMenu(int loadoutId, MenuEntry[] actions, MenuEntry firstEntry)
@@ -281,9 +281,13 @@ public class RunepouchLoadoutNamesPlugin extends Plugin
 		runepouchLoadoutContainer.revalidate();
 
 		int loadoutRowHeight = 0;
-		int loadoutWidgetIndex = 0;
-		for (var loadoutWidget : runepouchLoadoutContainer.getStaticChildren())
+		for (int loadoutWidgetIndex = 0; loadoutWidgetIndex < LOADOUT_INTERFACE_IDS.length; loadoutWidgetIndex++)
 		{
+			int loadoutWidgetID = LOADOUT_INTERFACE_IDS[loadoutWidgetIndex];
+
+			var loadoutWidget = client.getWidget(loadoutWidgetID);
+			if (loadoutWidget == null) continue;
+
 			var loadoutNameWidget = client.getWidget(loadoutWidget.getId() + 1);
 			var loadoutNameWidgetHeight = loadoutNameWidget.getHeight();
 
@@ -304,6 +308,7 @@ public class RunepouchLoadoutNamesPlugin extends Plugin
 				}
 
 				// Replace the rename button with the custom text
+				loadoutNameWidget.setHidden(false);
 				loadoutNameWidget.setType(WidgetType.TEXT);
 				loadoutNameWidget.setFontId(FontID.TAHOMA_11);
 				loadoutNameWidget.setTextColor(0xFF981F);
@@ -341,18 +346,16 @@ public class RunepouchLoadoutNamesPlugin extends Plugin
 					continue;
 				}
 			}
+		}
+
+		for (var loadEntry : LOAD_INTERFACE_IDS.entrySet()) {
+			int loadWidgetID = loadEntry.getKey();
+			int loadWidgetIndex = loadEntry.getValue();
 
 			// All of this is to handle the icon changing when hovering
-			Widget loadButton = null;
-			for (var loadoutWidgetChild : loadoutWidget.getStaticChildren()) {
-				if (loadoutWidgetChild.getType() == WidgetType.LAYER) {
-					loadButton = loadoutWidgetChild;
-					break;
-				}
-			}
-
+			Widget loadButton = client.getWidget(loadWidgetID);
 			if (loadButton != null) {
-				var loadoutIcon = getLoadoutIcon(loadoutWidgetIndex + 1);
+				var loadoutIcon = getLoadoutIcon(loadWidgetIndex);
 				var isCustomLoadoutIcon = loadoutIcon != DEFAULT_LOADOUT_ICON;
 
 				var loadButtonChildren = loadButton.getDynamicChildren();
@@ -360,7 +363,6 @@ public class RunepouchLoadoutNamesPlugin extends Plugin
 					final Widget loadButtonSprite = loadButtonChildren[loadButtonChildren.length - 1];
 					if (loadButtonSprite != null) {
 						loadButtonSprite.setSpriteId(loadoutIcon);
-
 						loadButtonSprite.setOriginalWidth(22);
 						loadButtonSprite.setOriginalHeight(22);
 						loadButtonSprite.setOpacity(50);
@@ -414,8 +416,6 @@ public class RunepouchLoadoutNamesPlugin extends Plugin
 					});
 				}
 			}
-
-			loadoutWidgetIndex++;
 		}
 
 		// Recalculate how far the container can scroll


### PR DESCRIPTION
Apply loadout and button changes based on interface ID array, rather than looping through widget children

Fixes: https://github.com/DapperMickie/runepouch-loadout-names/issues/9